### PR TITLE
Add drag & drop upload and vertical calendar

### DIFF
--- a/websites/ChatGPTUsageVisulaizer/calendar.js
+++ b/websites/ChatGPTUsageVisulaizer/calendar.js
@@ -22,8 +22,9 @@
       const label = document.createElement('div');
       label.className = 'month-label';
       label.textContent = m;
-      label.style.gridColumnStart = startWeek + 1;
-      label.style.gridColumnEnd = `span ${spanWeeks}`;
+      label.style.gridRowStart = startWeek + 1;
+      label.style.gridRowEnd = `span ${spanWeeks}`;
+      label.style.gridColumnStart = 1;
       calendar.appendChild(label);
     });
 
@@ -34,8 +35,8 @@
       const cell = document.createElement('div');
       cell.className = 'day';
       cell.dataset.date = d.toISOString().split('T')[0];
-      cell.style.gridColumnStart = weekIndex + 1;
-      cell.style.gridRowStart = dow + 2;
+      cell.style.gridRowStart = weekIndex + 1;
+      cell.style.gridColumnStart = dow + 2;
       calendar.appendChild(cell);
     }
 
@@ -43,7 +44,8 @@
       const label = document.createElement('div');
       label.className = 'week-label';
       label.textContent = (w + 1);
-      label.style.gridColumnStart = w + 1;
+      label.style.gridRowStart = w + 1;
+      label.style.gridColumnStart = 9;
       calendar.appendChild(label);
     }
   }

--- a/websites/ChatGPTUsageVisulaizer/index.html
+++ b/websites/ChatGPTUsageVisulaizer/index.html
@@ -5,11 +5,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ChatGPT Usage Calendar</title>
   <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet">
 </head>
 <body>
+  <h1>ChatGPT Nutzungskalender</h1>
+  <form class="form-container" enctype="multipart/form-data">
+    <div class="upload-files-container">
+      <div class="drag-file-area">
+        <span class="material-icons-outlined upload-icon">file_upload</span>
+        <h3 class="dynamic-message">Datei hierher ziehen</h3>
+        <label class="label">oder <span class="browse-files"> <input type="file" class="default-file-input"/> <span class="browse-files-text">Datei auswählen</span> <span>vom Gerät</span> </span></label>
+      </div>
+      <span class="cannot-upload-message"><span class="material-icons-outlined">error</span> Bitte wähle zuerst eine Datei aus <span class="material-icons-outlined cancel-alert-button">cancel</span></span>
+      <div class="file-block">
+        <div class="file-info"><span class="material-icons-outlined file-icon">description</span> <span class="file-name"></span> | <span class="file-size"></span></div>
+        <span class="material-icons remove-file-icon">delete</span>
+        <div class="progress-bar"></div>
+      </div>
+      <button type="button" class="upload-button">Upload</button>
+    </div>
+  </form>
   <div class="calendar-container">
     <div class="calendar" id="calendar"></div>
   </div>
+  <script src="upload.js"></script>
   <script src="calendar.js"></script>
   <script>
     // Beispiel: Kalender für das aktuelle Jahr erzeugen

--- a/websites/ChatGPTUsageVisulaizer/style.css
+++ b/websites/ChatGPTUsageVisulaizer/style.css
@@ -7,16 +7,17 @@ body {
 }
 
 .calendar-container {
-  overflow-x: auto;
+  overflow-y: auto;
+  max-height: 600px;
 }
 
 .calendar {
   display: grid;
-  grid-template-columns: repeat(var(--weeks, 53), 1fr);
-  grid-template-rows: auto repeat(7, 1fr) auto;
+  grid-template-columns: auto repeat(7, 1fr) auto;
+  grid-template-rows: repeat(var(--weeks, 53), 1fr);
   gap: 2px;
-  min-width: 800px;
-  height: 200px;
+  min-height: 800px;
+  width: 320px;
   box-sizing: border-box;
 }
 
@@ -28,8 +29,8 @@ body {
 }
 
 .month-label {
-  grid-row: 1;
-  text-align: center;
+  grid-column: 1;
+  text-align: right;
   font-weight: bold;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid #444c56;
@@ -39,7 +40,7 @@ body {
 }
 
 .week-label {
-  grid-row: 9;
+  grid-column: 9;
   text-align: center;
   font-size: 0.8em;
   background: rgba(255, 255, 255, 0.02);
@@ -47,4 +48,122 @@ body {
   box-sizing: border-box;
   padding: 2px 0;
   color: #c9d1d9;
+}
+/* Drag & Drop Upload */
+.form-container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+.upload-files-container {
+  background-color: #f7fff7;
+  width: 420px;
+  padding: 30px 60px;
+  border-radius: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  box-shadow: rgba(0, 0, 0, 0.24) 0px 10px 20px, rgba(0, 0, 0, 0.28) 0px 6px 6px;
+}
+.drag-file-area {
+  border: 2px dashed #007bff;
+  border-radius: 40px;
+  margin: 10px 0 15px;
+  padding: 30px 50px;
+  width: 350px;
+  text-align: center;
+}
+.drag-file-area .upload-icon {
+  font-size: 50px;
+}
+.drag-file-area h3 {
+  font-size: 26px;
+  margin: 15px 0;
+}
+.drag-file-area label {
+  font-size: 19px;
+}
+.drag-file-area label .browse-files-text {
+  color: #007bff;
+  font-weight: bolder;
+  cursor: pointer;
+}
+.browse-files span {
+  position: relative;
+  top: -25px;
+}
+.default-file-input {
+  opacity: 0;
+}
+.cannot-upload-message {
+  background-color: #ffc6c4;
+  font-size: 17px;
+  display: flex;
+  align-items: center;
+  margin: 5px 0;
+  padding: 5px 10px 5px 30px;
+  border-radius: 5px;
+  color: #BB0000;
+  display: none;
+}
+.cannot-upload-message span, .upload-button-icon {
+  padding-right: 10px;
+}
+.cannot-upload-message span:last-child {
+  padding-left: 20px;
+  cursor: pointer;
+}
+.file-block {
+  color: #f7fff7;
+  background-color: #007bff;
+  transition: all 1s;
+  width: 390px;
+  position: relative;
+  display: none;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin: 10px 0 15px;
+  padding: 10px 20px;
+  border-radius: 25px;
+  cursor: pointer;
+}
+.file-info {
+  display: flex;
+  align-items: center;
+  font-size: 15px;
+}
+.file-icon {
+  margin-right: 10px;
+}
+.file-name, .file-size {
+  padding: 0 3px;
+}
+.remove-file-icon {
+  cursor: pointer;
+}
+.progress-bar {
+  display: flex;
+  position: absolute;
+  bottom: 0;
+  left: 4.5%;
+  width: 0;
+  height: 5px;
+  border-radius: 25px;
+  background-color: #4BB543;
+}
+.upload-button {
+  font-family: 'Montserrat', sans-serif;
+  background-color: #007bff;
+  color: #f7fff7;
+  display: flex;
+  align-items: center;
+  font-size: 18px;
+  border: none;
+  border-radius: 20px;
+  margin: 10px;
+  padding: 7.5px 50px;
+  cursor: pointer;
 }

--- a/websites/ChatGPTUsageVisulaizer/upload.js
+++ b/websites/ChatGPTUsageVisulaizer/upload.js
@@ -1,0 +1,102 @@
+var isAdvancedUpload = function() {
+  var div = document.createElement('div');
+  return (('draggable' in div) || ('ondragstart' in div && 'ondrop' in div)) && 'FormData' in window && 'FileReader' in window;
+}();
+
+let draggableFileArea = document.querySelector(".drag-file-area");
+let browseFileText = document.querySelector(".browse-files");
+let uploadIcon = document.querySelector(".upload-icon");
+let dragDropText = document.querySelector(".dynamic-message");
+let fileInput = document.querySelector(".default-file-input");
+let cannotUploadMessage = document.querySelector(".cannot-upload-message");
+let cancelAlertButton = document.querySelector(".cancel-alert-button");
+let uploadedFile = document.querySelector(".file-block");
+let fileName = document.querySelector(".file-name");
+let fileSize = document.querySelector(".file-size");
+let progressBar = document.querySelector(".progress-bar");
+let removeFileButton = document.querySelector(".remove-file-icon");
+let uploadButton = document.querySelector(".upload-button");
+let fileFlag = 0;
+
+fileInput.addEventListener("click", () => {
+  fileInput.value = '';
+});
+
+fileInput.addEventListener("change", e => {
+  uploadIcon.innerHTML = 'check_circle';
+  dragDropText.innerHTML = 'Datei erfolgreich geladen!';
+  document.querySelector(".label").innerHTML = `drag & drop oder <span class="browse-files"> <input type="file" class="default-file-input" style=""/> <span class="browse-files-text" style="top: 0;"> Datei auswählen</span></span>`;
+  uploadButton.innerHTML = `Upload`;
+  fileName.innerHTML = fileInput.files[0].name;
+  fileSize.innerHTML = (fileInput.files[0].size/1024).toFixed(1) + " KB";
+  uploadedFile.style.cssText = "display: flex;";
+  progressBar.style.width = 0;
+  fileFlag = 0;
+});
+
+uploadButton.addEventListener("click", () => {
+  let isFileUploaded = fileInput.value;
+  if(isFileUploaded != '') {
+    if (fileFlag == 0) {
+      fileFlag = 1;
+      var width = 0;
+      var id = setInterval(frame, 50);
+      function frame() {
+        if (width >= 390) {
+          clearInterval(id);
+          uploadButton.innerHTML = `<span class="material-icons-outlined upload-button-icon"> check_circle </span> Hochgeladen`;
+        } else {
+          width += 5;
+          progressBar.style.width = width + "px";
+        }
+      }
+    }
+  } else {
+    cannotUploadMessage.style.cssText = "display: flex; animation: fadeIn linear 1.5s;";
+  }
+});
+
+cancelAlertButton.addEventListener("click", () => {
+  cannotUploadMessage.style.cssText = "display: none;";
+});
+
+if(isAdvancedUpload) {
+  ["drag", "dragstart", "dragend", "dragover", "dragenter", "dragleave", "drop"].forEach( evt => 
+    draggableFileArea.addEventListener(evt, e => {
+      e.preventDefault();
+      e.stopPropagation();
+    })
+  );
+
+  ["dragover", "dragenter"].forEach( evt => {
+    draggableFileArea.addEventListener(evt, e => {
+      e.preventDefault();
+      e.stopPropagation();
+      uploadIcon.innerHTML = 'file_download';
+      dragDropText.innerHTML = 'Datei hier ablegen';
+    });
+  });
+
+  draggableFileArea.addEventListener("drop", e => {
+    uploadIcon.innerHTML = 'check_circle';
+    dragDropText.innerHTML = 'Datei erfolgreich geladen!';
+    document.querySelector(".label").innerHTML = `drag & drop oder <span class="browse-files"> <input type="file" class="default-file-input" style=""/> <span class="browse-files-text" style="top: -23px; left: -20px;"> Datei auswählen</span> </span>`;
+    uploadButton.innerHTML = `Upload`;
+    let files = e.dataTransfer.files;
+    fileInput.files = files;
+    fileName.innerHTML = files[0].name;
+    fileSize.innerHTML = (files[0].size/1024).toFixed(1) + " KB";
+    uploadedFile.style.cssText = "display: flex;";
+    progressBar.style.width = 0;
+    fileFlag = 0;
+  });
+}
+
+removeFileButton.addEventListener("click", () => {
+  uploadedFile.style.cssText = "display: none;";
+  fileInput.value = '';
+  uploadIcon.innerHTML = 'file_upload';
+  dragDropText.innerHTML = 'Datei hierher ziehen';
+  document.querySelector(".label").innerHTML = `oder <span class="browse-files"> <input type="file" class="default-file-input"/> <span class="browse-files-text">Datei auswählen</span> <span>vom Gerät</span> </span>`;
+  uploadButton.innerHTML = `Upload`;
+});


### PR DESCRIPTION
## Summary
- add Upload-Formular und Kalender-Headline
- binde `upload.js` ein
- passe Kalenderlayout an vertikale Ausrichtung an
- füge neue Styles für Drag & Drop Bereich in Blau hinzu

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c3c88dcf48330a34f98097633df64